### PR TITLE
Checking if two adjacent vertices are close enough

### DIFF
--- a/sphericalpolygon/excess_area.py
+++ b/sphericalpolygon/excess_area.py
@@ -29,7 +29,7 @@ def polygon_excess(vertices):
         dlon = np.abs(pdlon) 
         
         # If two adjacent vertices are close enough(coincident), do nothing. 
-        if dlon < 1e-6 and np.abs(pdlat): continue 
+        if dlon < 1e-6 and np.abs(pdlat) < 1e-6: continue 
 
         # Calculate the area of a spherical triangle consisting of sides and north poles  
         if dlon > np.pi: dlon = 2*np.pi - dlon 

--- a/sphericalpolygon/excess_area.py
+++ b/sphericalpolygon/excess_area.py
@@ -29,7 +29,7 @@ def polygon_excess(vertices):
         dlon = np.abs(pdlon) 
         
         # If two adjacent vertices are close enough(coincident), do nothing. 
-        if dlon < 1e-6: continue 
+        if dlon < 1e-6 and np.abs(pdlat): continue 
 
         # Calculate the area of a spherical triangle consisting of sides and north poles  
         if dlon > np.pi: dlon = 2*np.pi - dlon 


### PR DESCRIPTION
To check if two adjacent vertices are close enough both dlon and pdlat need to be close to zero. Only dlon close to zero can happen if the points happen to lie on the same longitude line.